### PR TITLE
Fix code scanning alert no. 230: Database query built from user-controlled sources

### DIFF
--- a/utils/utilFunctions.js
+++ b/utils/utilFunctions.js
@@ -1135,9 +1135,14 @@ GROUP BY
         // Insert into LinkPreviewData table
         const insertLinkPreviewDataQuery = `
           INSERT INTO LinkPreviewData (link, image_url, description, title, favicon)
-          VALUES ('${preview.url}', '${preview.image}', '${preview.description}', '${preview.title}', '${preview.favicon}')
+          VALUES (@link, @image_url, @description, @title, @favicon)
         `;
-        await sql.query(insertLinkPreviewDataQuery);
+        await sql.query(insertLinkPreviewDataQuery)
+          .input('link', sql.VarChar, preview.url)
+          .input('image_url', sql.VarChar, preview.image)
+          .input('description', sql.VarChar, preview.description)
+          .input('title', sql.VarChar, preview.title)
+          .input('favicon', sql.VarChar, preview.favicon);
 
         return preview;
       }


### PR DESCRIPTION
Fixes [https://github.com/getcore-dev/core/security/code-scanning/230](https://github.com/getcore-dev/core/security/code-scanning/230)

To fix the problem, we need to use parameterized queries to safely embed user input into the SQL query. This approach ensures that the user input is treated as a literal value and not as part of the SQL command, preventing SQL injection attacks.

1. Modify the `insertLinkPreviewDataQuery` to use parameterized queries.
2. Use the `input` method provided by the `mssql` library to bind the user input to the query parameters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
