### PR TITLE
Fix code scanning alert no. 146: Host header poisoning in email generation

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -12,6 +12,7 @@ const { v4: uuidv4 } = require('uuid');
 const nodemailer = require('nodemailer');
 const userQueries = require('../queries/userQueries');
 const notificationQueries = require('../queries/notificationQueries');
+const config = require('../config'); // Add this line to import the configuration
 
 // Set up nodemailer transporter
 const transporter = nodemailer.createTransport({
@@ -58,7 +59,7 @@ router.post('/reset-password', async (req, res) => {
     await sql.query`UPDATE users SET reset_password_token = ${resetToken}, reset_password_expires = ${resetTokenExpires} WHERE id = ${user.id}`;
 
     // Send reset email
-    const resetUrl = `http://${req.headers.host}/reset-password/${resetToken}`;
+    const resetUrl = `http://${config.hostname}/reset-password/${resetToken}`; // Use configured hostname
     const mailOptions = {
       from: '"CORE Support" <support@getcore.dev>',
       to: user.email,


### PR DESCRIPTION
Fixes [https://github.com/getcore-dev/core/security/code-scanning/146](https://github.com/getcore-dev/core/security/code-scanning/146)

To fix the problem, we need to avoid using the `req.headers.host` to construct the reset URL. Instead, we should use a hostname that is configured in a secure manner, such as from a configuration file or environment variable. This ensures that the URL in the email always points to the legitimate site.

1. Add a configuration file or environment variable to store the hostname.
2. Modify the code to use this configured hostname instead of `req.headers.host`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
