### PR TITLE
Fix code scanning alert no. 189: DOM text reinterpreted as HTML

### DIFF
--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -597,7 +597,12 @@
     document.querySelectorAll('.search-category').forEach(category => {
       category.addEventListener('click', function () {
         const selectedCategory = this.getAttribute('data-category');
-        window.location.href = `/search?searchTerm=${encodeURIComponent(searchBar.value)}&category=${selectedCategory}`;
+        const allowedCategories = ['posts', 'companies', 'users', 'jobs'];
+        if (allowedCategories.includes(selectedCategory)) {
+          window.location.href = `/search?searchTerm=${encodeURIComponent(searchBar.value)}&category=${selectedCategory}`;
+        } else {
+          console.warn('Invalid category selected');
+        }
       });
     });
 


### PR DESCRIPTION
Fixes [https://github.com/getcore-dev/core/security/code-scanning/189](https://github.com/getcore-dev/core/security/code-scanning/189)

To fix the problem, we need to ensure that the `data-category` attribute is properly sanitized before being used in the URL construction. This can be achieved by validating the `data-category` value against a list of allowed categories. If the value is not in the list of allowed categories, it should be discarded or replaced with a safe default value.

The best way to fix the problem without changing existing functionality is to introduce a validation step for the `data-category` attribute. We will create a list of allowed categories and check if the `selectedCategory` is in this list before using it in the URL construction.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
