### PR TITLE
Fix code scanning alert no. 165: Exception text reinterpreted as HTML

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "session-file-store": "^1.5.0",
     "turndown": "^7.2.0",
     "uuid": "^11.0.2",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "he": "^1.2.0"
   },
   "devDependencies": {
     "globals": "^15.8.0",

--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -6,6 +6,7 @@ const multer = require("multer");
 const { checkAuthenticated } = require("../middleware/authMiddleware");
 const fs = require("fs");
 const path = require("path");
+const he = require("he");
 const JobProcessor = require("../services/jobBoardService");
 const jobProcessor = new JobProcessor();
 const githubService = require("../services/githubService");
@@ -1674,7 +1675,7 @@ router.get("/communities/:communitiesId", async (req, res) => {
 
     res.json(communities);
   } catch (err) {
-    res.status(500).send(err.message);
+    res.status(500).send(he.encode(err.message));
   }
 });
 
@@ -1685,7 +1686,7 @@ router.get("/link-preview/:link", cacheMiddleware(1200), async (req, res) => {
     res.json(linkPreview);
   } catch (err) {
     console.error("Error in link preview route:", err);
-    res.status(500).send(err.message);
+    res.status(500).send(he.encode(err.message));
   }
 });
 


### PR DESCRIPTION
Fixes [https://github.com/getcore-dev/core/security/code-scanning/165](https://github.com/getcore-dev/core/security/code-scanning/165)

To fix the problem, we need to ensure that any error messages sent in the response are properly sanitized or escaped to prevent XSS vulnerabilities. The best way to fix this without changing existing functionality is to use a library like `he` (HTML entities) to escape the error message before sending it in the response.

1. Install the `he` library to handle HTML entity encoding.
2. Import the `he` library in the file.
3. Use the `he.encode` function to escape the error message before sending it in the response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
