### PR TITLE
Fix code scanning alert no. 122: Server-side request forgery

### DIFF
--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -408,6 +408,13 @@ router.get(
   async (req, res) => {
     try {
       const username = req.params.username;
+      
+      // Validate the username parameter
+      const usernamePattern = /^[a-zA-Z0-9-]+$/;
+      if (!usernamePattern.test(username)) {
+        return res.status(400).json({ error: "Invalid GitHub username" });
+      }
+
       const user = await userQueries.findByGitHubUsername(username);
 
       if (!user || !user.githubAccessToken) {


### PR DESCRIPTION
Fixes [https://github.com/getcore-dev/core/security/code-scanning/122](https://github.com/getcore-dev/core/security/code-scanning/122)

To fix the problem, we need to ensure that the user-provided value (`username`) is validated against a whitelist of allowed values or patterns before it is used to construct the URL. This will prevent any malicious input from being used to forge requests to unintended endpoints.

1. Validate the `username` parameter to ensure it conforms to expected patterns (e.g., GitHub usernames).
2. Use a regular expression to validate the `username` before constructing the URL.
3. If the `username` is invalid, return an appropriate error response.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
